### PR TITLE
Use the asset href argument in create-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   - [raster](https://github.com/stac-extensions/raster)
   - [scientific](https://github.com/stac-extensions/scientific)
 
-DRCOG provides the original data in a geodatabase. GDAL, a translator library for raster and vector geospatial data formats, was utilized to generate a cloud optimized GeoTIFF (COG). 
+DRCOG provides the original data in a geodatabase. GDAL, a translator library for raster and vector geospatial data formats, was utilized to generate a cloud optimized GeoTIFF (COG).
 
 This repository will assist you in the generation of STAC files for 2018 Denver Regional Council of Goverments (DRCOG) high resolution Land Use Land Cover (LULC) dataset.
 
@@ -21,21 +21,22 @@ This repository will assist you in the generation of STAC files for 2018 Denver 
 ### STAC objects
 
 - [Collection](examples/collection.json)
-- [Item](examples/item/drcog-lulc-hr-pilot.json)
+- [Item](examples/drcog-lulc-hr-pilot/drcog-lulc-hr-pilot.json)
 
 ### Command-line usage
 
 To create a STAC `Item`:
 
 ```bash
-$ stac drcog-lulc create-item tests/data-files/drcog_lulc_hr_pilot_1m.tif item.json
+stac drcog-lulc create-item tests/data-files/drcog_lulc_hr_pilot_1m.tif item.json
 ```
 
 To create a STAC `Collection` from a list of DRCOG asset hrefs:
 
 ```bash
-$ stac drcog-lulc create-collection examples/file-list.txt examples 
+stac drcog-lulc create-collection examples --asset-href tests/data-files/drcog_lulc_hr_pilot_1m.tif
 ```
+
 The above `create-collection` command is exactly how the contents of the `examples` directory are generated.
 
 Use `stac drcog-lulc --help` to see all subcommands and options.

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -6,7 +6,7 @@
   "links": [
     {
       "rel": "root",
-      "href": "/Users/pholleway/Code/drcog-lulc/examples/file-list.txt",
+      "href": "./collection.json",
       "type": "application/json",
       "title": "DRCOG LULC 2018"
     },
@@ -26,8 +26,8 @@
       "title": "DRCOG_Final_Classification"
     },
     {
-      "rel": "self",
-      "href": "/Users/pholleway/Code/drcog-lulc/examples/file-list.txt",
+      "rel": "item",
+      "href": "./drcog-lulc-hr-pilot/drcog-lulc-hr-pilot.json",
       "type": "application/json"
     }
   ],

--- a/examples/drcog-lulc-hr-pilot/drcog-lulc-hr-pilot.json
+++ b/examples/drcog-lulc-hr-pilot/drcog-lulc-hr-pilot.json
@@ -1,0 +1,145 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "drcog-lulc-hr-pilot",
+  "properties": {
+    "proj:epsg": 26913,
+    "proj:transform": [
+      1.0,
+      0.0,
+      501563.89506094216,
+      0.0,
+      -1.0,
+      4410957.855446822
+    ],
+    "proj:shape": [
+      3132,
+      3299
+    ],
+    "start_datetime": "2018-01-01T00:00:00Z",
+    "end_datetime": "2018-12-31T23:59:59Z",
+    "description": "DRCOG LULC at 1m resolution for year 2018",
+    "created": "2022-05-13T15:05:27.856696Z",
+    "mission": "DRCOG LULC",
+    "datetime": null
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -104.943179,
+          39.820406
+        ],
+        [
+          -104.943156,
+          39.848625
+        ],
+        [
+          -104.981719,
+          39.848638
+        ],
+        [
+          -104.981727,
+          39.820418
+        ],
+        [
+          -104.943179,
+          39.820406
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../collection.json",
+      "type": "application/json",
+      "title": "DRCOG LULC 2018"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json",
+      "title": "DRCOG LULC 2018"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json",
+      "title": "DRCOG LULC 2018"
+    }
+  ],
+  "assets": {
+    "data": {
+      "href": "../../tests/data-files/drcog_lulc_hr_pilot_1m.tif",
+      "title": "DRCOG LULC",
+      "description": "Denver Regional Council of Governments (DRCOG) Land Use Land Cover (LULC) classifications",
+      "bands": [
+        {
+          "description": "Classification values",
+          "sampling": "area",
+          "data_type": "uint8",
+          "spatial_resolution": 1
+        }
+      ],
+      "classes": [
+        {
+          "value": 1,
+          "description": "Structures",
+          "color_hint": "FF0000"
+        },
+        {
+          "value": 2,
+          "description": "Impervious Surfaces",
+          "color_hint": "B2B2B2"
+        },
+        {
+          "value": 3,
+          "description": "Water",
+          "color_hint": "00A9E6"
+        },
+        {
+          "value": 4,
+          "description": "Prairie/Grassland/Natural Ground Cover",
+          "color_hint": "C7D79E"
+        },
+        {
+          "value": 5,
+          "description": "Tree Canopy",
+          "color_hint": "267300"
+        },
+        {
+          "value": 6,
+          "description": "Turf/Irrigated Land",
+          "color_hint": "70A800"
+        },
+        {
+          "value": 7,
+          "description": "Barren Land",
+          "color_hint": "FFEBAF"
+        },
+        {
+          "value": 8,
+          "description": "Cropland",
+          "color_hint": "FFAE42"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "bbox": [
+    -104.981727,
+    39.820406,
+    -104.943156,
+    39.848638
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
+  "collection": "drcog-lulc"
+}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -14,22 +14,17 @@ class CommandsTest(CliTestCase):
         return [create_drcog_lulc_command]
 
     def test_create_collection(self):
-        with TemporaryDirectory() as tmp_dir:
-            # Run your custom create-collection command and validate
-
-            # Example:
-            destination = os.path.join(tmp_dir, "collection.json")
-
-            result = self.run_command(["drcog-lulc", "create-collection", destination])
-
+        with TemporaryDirectory() as temporary_directory:
+            result = self.run_command(
+                ["drcog-lulc", "create-collection", temporary_directory]
+            )
             self.assertEqual(result.exit_code, 0, msg="\n{}".format(result.output))
 
-            jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
+            jsons = [p for p in os.listdir(temporary_directory) if p.endswith(".json")]
             self.assertEqual(len(jsons), 1)
 
-            collection = pystac.read_file(destination)
+            collection = pystac.read_file(os.path.join(temporary_directory, jsons[0]))
             self.assertEqual(collection.id, "drcog-lulc")
-            # self.assertEqual(item.other_attr...
 
             collection.validate()
 


### PR DESCRIPTION
**Related Issue(s):**
- Helps along #13 

**Description:**
Enable the asset href argument for the command and use it to create the examples.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Examples are added to `examples/`
